### PR TITLE
Travis-CI: remove macOS gcc 4.8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,6 @@ matrix:
       osx_image: xcode8.3
       env: CC='clang' CXX='clang++' CFLAGS='-DNRUNS=100000000' BREW=''
     - os: osx
-      env: CC='gcc-4.8' CXX='g++-4.8' CFLAGS='-DNRUNS=100000000' BREW='gcc@4.8'
-    - os: osx
       env: CC='gcc-4.9' CXX='g++-4.9' FC='gfortran-4.9' CFLAGS='-DNRUNS=100000000' BREW='gcc@4.9'
     - os: osx
       env: CC='gcc-5' CXX='g++-5' FC='gfortran-5' CFLAGS='-DNRUNS=100000000' BREW='gcc@5'


### PR DESCRIPTION
compiler is no longer available from Homebrew